### PR TITLE
(#5) 회원가입 페이지 마크업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,14 @@ import Login from './pages/Login';
 
 import 'antd/dist/antd.css';
 import './App.scss';
+import SignupPage from './pages/Signup';
 
 const App = () => {
   return (
     <ConnectedRouter history={history}>
       <Switch>
         <PublicLayout path="/login" component={Login} />
+        <PublicLayout path="/signup" component={SignupPage} />
         <DefaultLayout path="/" component={Home} />
       </Switch>
     </ConnectedRouter>

--- a/src/components/Input/BasicInput.scss
+++ b/src/components/Input/BasicInput.scss
@@ -18,6 +18,6 @@
   }
 
   & + .basic-input {
-    margin-top: 26px;
+    margin-top: 12px;
   }
 }

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -16,6 +16,7 @@ interface Props {
   message?: string;
   required?: boolean;
   requiredStyle?: boolean;
+  placeholder?: string;
 }
 
 export const BasicInput = ({
@@ -25,6 +26,7 @@ export const BasicInput = ({
   message,
   required = true,
   requiredStyle = false,
+  placeholder = '',
 }: Props): JSX.Element => {
   let Component;
 
@@ -54,7 +56,7 @@ export const BasicInput = ({
       help={<p className="basic-input__message">{message}</p>}
       validateStatus="error"
       className={cx('basic-input')}>
-      <Component className={cx('basic-input__input', 'round')} />
+      <Component className={cx('basic-input__input', 'round')} placeholder={placeholder} />
     </Form.Item>
   );
 };

--- a/src/components/Text/PageSubTitle.scss
+++ b/src/components/Text/PageSubTitle.scss
@@ -1,0 +1,13 @@
+.page-sub-title {
+  font-size: 18px;
+  line-height: 30px;
+  color: #000;
+  text-align: center;
+}
+
+@media (max-width: 320px) {
+  .ant-typography.page-sub-title {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}

--- a/src/components/Text/PageSubTitle.tsx
+++ b/src/components/Text/PageSubTitle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import cx from 'classnames';
+
+import './PageSubTitle.scss';
+import Paragraph from 'antd/lib/typography/Paragraph';
+
+interface Props {
+  text: string;
+  className?: string;
+}
+
+const PageSubTitle = ({ className = '', text }: Props): JSX.Element => {
+  return (
+    <Paragraph strong={true} className={cx('page-sub-title', className)}>
+      {text}
+    </Paragraph>
+  );
+};
+
+export default PageSubTitle;

--- a/src/components/Text/PageTitle.scss
+++ b/src/components/Text/PageTitle.scss
@@ -1,0 +1,13 @@
+.ant-typography.page-title {
+  font-size: 30px;
+  line-height: 44px;
+  color: #000;
+  text-align: center;
+}
+
+@media (max-width: 320px) {
+  .ant-typography.page-title {
+    font-size: 25px;
+    line-height: 30px;
+  }
+}

--- a/src/components/Text/PageTitle.tsx
+++ b/src/components/Text/PageTitle.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import cx from 'classnames';
+import Title from 'antd/lib/typography/Title';
+
+import './PageTitle.scss';
+
+interface Props {
+  text: string;
+  level?: 1 | 2 | 3 | 4 | 5;
+  className?: string;
+}
+
+const PageTitle = ({ level = 2, className = '', text }: Props): JSX.Element => {
+  return (
+    <Title level={level} className={cx('page-title', className)}>
+      {text}
+    </Title>
+  );
+};
+
+export default PageTitle;

--- a/src/components/common/CenterLayout.scss
+++ b/src/components/common/CenterLayout.scss
@@ -1,0 +1,6 @@
+.center-layout {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 20px 30px;
+}

--- a/src/components/common/CenterLayout.tsx
+++ b/src/components/common/CenterLayout.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode } from 'react';
+import cx from 'classnames';
+
+import './CenterLayout.scss';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  innerClassName?: string;
+}
+
+const CenterLayout = ({ className = '', innerClassName = '', children }: Props): JSX.Element => {
+  return (
+    <div className={cx('center-layout', className)}>
+      <div className={cx('center-layout__inner', innerClassName)}>{children}</div>
+    </div>
+  );
+};
+
+export default CenterLayout;

--- a/src/pages/Login/index.scss
+++ b/src/pages/Login/index.scss
@@ -1,26 +1,11 @@
 .login-page {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-  min-height: 100vh;
-
   .login-page__inner {
     width: 100%;
     max-width: 466px;
-  }
-  .login-page__tit {
-    font-size: 30px;
-    line-height: 44px;
-    color: #000;
-    text-align: center;
+    margin-top: 200px;
   }
   .login-page__sub-tit {
     margin-top: 20px;
-    font-size: 18px;
-    line-height: 30px;
-    color: #000;
-    text-align: center;
   }
   .login-page__form-container {
     display: flex;
@@ -29,6 +14,7 @@
   }
   .login-page__forget-link {
     align-self: flex-end;
+    margin-top: 10px;
     font-size: 16px;
     line-height: 30px;
     color: #727272;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -2,36 +2,31 @@ import React from 'react';
 
 import { Form } from 'antd';
 import { Link } from 'react-router-dom';
-import Title from 'antd/lib/typography/Title';
-import Paragraph from 'antd/lib/typography/Paragraph';
 
+import CenterLayout from '@comp/common/CenterLayout';
 import { BasicInput } from '@comp/Input';
 import { SubmitBtn } from '@comp/Button';
 
 import './index.scss';
+import PageTitle from '@comp/Text/PageTitle';
+import PageSubTitle from '@comp/Text/PageSubTitle';
 
 const LoginPage = (): JSX.Element => {
   return (
-    <div className="login-page">
-      <div className="login-page__inner">
-        <Title level={2} className="login-page__tit">
-          마이펫밀리 파트너 로그인
-        </Title>
-        <Paragraph strong={true} className="login-page__sub-tit">
-          마이펫밀리의 회원이 되어보세요!
-        </Paragraph>
-        <Form name="user">
-          <div className="login-page__form-container">
-            <BasicInput type="text" label="이메일" name="email" message="이메일을 입력해주세요" />
-            <BasicInput type="password" label="비밀번호" name="password" message="비밀번호를 입력해주세요" />
-            <Link to="/forget_auth" className="login-page__forget-link">
-              아이디 / 비밀번호를 잊어버렸어요!
-            </Link>
-            <SubmitBtn className="login-page__submit-btn">로그인</SubmitBtn>
-          </div>
-        </Form>
-      </div>
-    </div>
+    <CenterLayout className="login-page" innerClassName="login-page__inner">
+      <PageTitle text="마이팻밀리 파트너 로그인" />
+      <PageSubTitle className="login-page__sub-tit" text="마이펫밀리의 회원이 되어보세요!" />
+      <Form name="user">
+        <div className="login-page__form-container">
+          <BasicInput type="text" label="이메일" name="email" message="이메일을 입력해주세요" />
+          <BasicInput type="password" label="비밀번호" name="password" message="비밀번호를 입력해주세요" />
+          <Link to="/forget_auth" className="login-page__forget-link">
+            아이디 / 비밀번호를 잊어버렸어요!
+          </Link>
+          <SubmitBtn className="login-page__submit-btn">로그인</SubmitBtn>
+        </div>
+      </Form>
+    </CenterLayout>
   );
 };
 

--- a/src/pages/Signup/index.scss
+++ b/src/pages/Signup/index.scss
@@ -1,0 +1,14 @@
+.signup-page {
+  .signup-page__inner {
+    width: 100%;
+    max-width: 510px;
+    margin-top: 130px;
+  }
+  .signup-page__form-container {
+    margin-top: 108px;
+  }
+  .signup-page__submit-btn {
+    width: 68%;
+    margin: 70px auto 0;
+  }
+}

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import Form from 'antd/lib/form/Form';
+
+import { SubmitBtn } from '@comp/Button';
+import CenterLayout from '@comp/common/CenterLayout';
+import { BasicInput } from '@comp/Input';
+import PageTitle from '@comp/Text/PageTitle';
+
+import './index.scss';
+
+const SignupPage = (): JSX.Element => {
+  return (
+    <CenterLayout className="signup-page" innerClassName="signup-page__inner">
+      <PageTitle text="파트너 회원가입" />
+      <Form name="user">
+        <div className="signup-page__form-container">
+          <BasicInput
+            type="text"
+            label="이름"
+            name="username"
+            message="이름을 입력해주세요."
+            placeholder="실명을 기입해주세요."
+          />
+          <BasicInput
+            type="text"
+            label="이메일"
+            name="email"
+            message="올바른 이메일을 입력해주세요."
+            placeholder="abc@gmail.com"
+          />
+          <BasicInput
+            type="text"
+            label="휴대전화번호"
+            name="phone"
+            message="올바른 휴대전화번호를 입력해주세요."
+            placeholder="010-****-****"
+          />
+          <BasicInput
+            type="password"
+            label="비밀번호"
+            name="password"
+            message="올바른 비밀번호를 입력해주세요."
+            placeholder="비밀번호를 입력해주세요."
+          />
+          <BasicInput
+            type="password"
+            label="비밀번호 확인"
+            name="passwordCheck"
+            message="입력한 비밀번호와 다릅니다."
+            placeholder="비밀번호를 다시 입력해주세요."
+          />
+          <SubmitBtn className="signup-page__submit-btn">회원가입</SubmitBtn>
+        </div>
+      </Form>
+    </CenterLayout>
+  );
+};
+
+export default SignupPage;

--- a/src/style/global.scss
+++ b/src/style/global.scss
@@ -121,6 +121,6 @@ table {
 body {
   background: #fcfdff;
 }
-:global(#root) {
+#root {
   min-height: 100vh;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,7 +54,7 @@
     "paths": {
       "@": ["./src"],
       "@comp/*": ["components/*"],
-      "@st": ["style/*"]
+      "@st/*": ["style/*"]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
## 이슈
#5

## 참고사항
- #8 에선 언급하지 않았지만 css module 방식에서 일반 scss 방식으로 변경
   - css module의 unique 클래스명을 보완하기 위해서 BEM 명명 기법 도입
- BasicInput 컴포넌트 변경, Submit은 `components/Button/SubmitBtn` 으로 분리
- 로그인 페이지 레이아웃을 중앙 정렬형 레이아웃 컴포넌트로 분리(`components/common/CenterLayout)`
- 페이지의 제목, 부제목을 컴포넌트로 분리(`components/Text`)

## 스크린샷
![image](https://user-images.githubusercontent.com/40534721/104103369-08967a80-52e5-11eb-8c25-94d456bef039.png)
